### PR TITLE
LP-698 sg-secure-gateway-should-not-be-hiding-the-sites-area-in-the-ui

### DIFF
--- a/app/src/routes/index.ts
+++ b/app/src/routes/index.ts
@@ -23,7 +23,7 @@ import 'nprogress/nprogress.css'
 // Combine child routes for the main layout
 const mainLayoutChildren: RouteRecordRaw[] = [
   ...dashboardRoutes,
-  // ...sitesRoutes,
+  ...sitesRoutes,
   // ...streamsRoutes,
   // ...configRoutes,
   ...certificatesRoutes,


### PR DESCRIPTION
-Enabled manage site routes in the UI