### PR TITLE
NG-628 secure-gateway-workspace-button-splits-the-screen-and-displays-apporto-menu-twice issue fixed

### DIFF
--- a/app/src/layouts/HeaderLayout.vue
+++ b/app/src/layouts/HeaderLayout.vue
@@ -57,14 +57,6 @@ const { width: userWrapperWidth } = useElementSize(userWrapperRef)
 
       <SwitchAppearance />
 
-      <div v-if="!isWorkspace" class="workspace-entry">
-        <RouterLink to="/workspace">
-          <ATooltip :title="$gettext('Workspace')">
-            <DesktopOutlined />
-          </ATooltip>
-        </RouterLink>
-      </div>
-
       <ProcessingStatus />
 
       <Notification :header-ref="headerRef" />
@@ -109,12 +101,6 @@ const { width: userWrapperWidth } = useElementSize(userWrapperRef)
   position: absolute;
   left: 20px;
   @media (min-width: 600px) {
-    display: none;
-  }
-}
-
-.workspace-entry {
-  @media (max-width: 600px) {
     display: none;
   }
 }

--- a/app/src/routes/index.ts
+++ b/app/src/routes/index.ts
@@ -48,14 +48,14 @@ export const routes: RouteRecordRaw[] = [
     },
     children: mainLayoutChildren,
   },
-  {
-    path: '/workspace',
-    name: 'Workspace',
-    component: () => import('@/views/workspace/WorkSpace.vue'),
-    meta: {
-      name: () => $gettext('Workspace'),
-    },
-  },
+  // {
+  //   path: '/workspace',
+  //   name: 'Workspace',
+  //   component: () => import('@/views/workspace/WorkSpace.vue'),
+  //   meta: {
+  //     name: () => $gettext('Workspace'),
+  //   },
+  // },
   ...authRoutes,
   ...errorRoutes,
 ]


### PR DESCRIPTION
Removed the WorkSpace button from the navigation bar and commented out its associated routes based on James' suggestion.

Note:
The `WorkSpace.vue` component has not been deleted to allow for easy reactivation in the future with minimal changes.